### PR TITLE
feat: add pay-respects formula

### DIFF
--- a/Formula/pay-respects.rb
+++ b/Formula/pay-respects.rb
@@ -1,0 +1,39 @@
+class PayRespects < Formula
+  desc "Command suggestions, command-not-found and thefuck replacement in Rust"
+  homepage "https://github.com/iffse/pay-respects"
+  version "0.8.8"
+  license "AGPL-3.0-or-later"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/iffse/pay-respects/releases/download/v#{version}/pay-respects-#{version}-aarch64-apple-darwin.tar.zst"
+      sha256 "e834e928dcaf9cd72a99478bb61e0630ba76e32c7b228eb3a7be9c5f404cd548"
+    end
+    on_intel do
+      url "https://github.com/iffse/pay-respects/releases/download/v#{version}/pay-respects-#{version}-x86_64-apple-darwin.tar.zst"
+      sha256 "64c30e1a62605279abf219193c53bf251687ea419a0c99d2e15ae8b5b6a58587"
+    end
+  end
+
+  def install
+    bin.install "pay-respects"
+    bin.install Dir["_pay-respects-*"]
+    man1.install "man/pay-respects.1"
+    man5.install "man/pay-respects.5"
+    man5.install "man/pay-respects-modules.5"
+    man5.install "man/pay-respects-rules.5"
+  end
+
+  def caveats
+    <<~EOS
+      To enable the `f` shell alias, add to your ~/.zshrc:
+        eval "$(pay-respects zsh --alias)"
+
+      Replaces `thefuck` with a much faster Rust implementation.
+    EOS
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pay-respects --version")
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `pay-respects` (Rust-based `thefuck` replacement, ~10x faster startup) as a tap formula
- Uses prebuilt `apple-darwin` binaries from upstream releases (arm64 + x86_64)
- Bundles man pages and zsh completion modules

## Why
`thefuck` (Python) adds ~9ms to shell startup even with cached `--alias` output. `pay-respects` is sub-millisecond.

## Test plan
- [ ] `brew tap jacobfg/taps && brew install pay-respects`
- [ ] `pay-respects --version` → `0.8.8`
- [ ] `eval "$(pay-respects zsh --alias)"` and verify `f` alias works

🤖 Generated with [Claude Code](https://claude.com/claude-code)